### PR TITLE
Add web server dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.DS_Store
 .env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,8 @@ services:
             - 4433:443
         container_name: tonic_worker
         mem_limit: 10240m
+        depends_on:
+          - tonic_web_server
         networks:
           - tonic-ai
     tonic_notifications:
@@ -73,6 +75,8 @@ services:
             options:
                 max-size: "200m"
                 max-file: "2"
+        depends_on:
+          - tonic_web_server
         networks:
           - tonic-ai
     tonic_pyml_service:


### PR DESCRIPTION
Avoids temporary errors during start-up on a new version if the worker or notifications starts and connects to the database before the web server has started and run migrations.